### PR TITLE
CognitoUser improvements

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -47,7 +47,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.3.2.14" />
-    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.3.5" />
+    <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.3.101.34" />
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.3.107.26" />
   </ItemGroup>
 </Project>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -110,6 +110,22 @@ namespace Amazon.Extensions.CognitoAuthentication
     }
 
     /// <summary>
+    /// Class containing the necessary properities to respond to an software MFA authentication challenge
+    /// </summary>
+    public class RespondToSoftwareMfaRequest
+    {
+        /// <summary>
+        /// The session ID for the current authentication flow.
+        /// </summary>
+        public string SessionID { get; set; }
+
+        /// <summary>
+        /// The MFA verification code needed to authenticate the user.
+        /// </summary>
+        public string MfaCode { get; set; }
+    }
+
+    /// <summary>
     /// Class containing the necessary properities to respond to a new password required authentication challenge
     /// </summary>
     public class RespondToNewPasswordRequiredRequest

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoAuthHelper.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoAuthHelper.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Reflection;
 
@@ -64,6 +65,8 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
 
             return Convert.ToBase64String(hashMessage);
         }
+
+        internal static string UtcNow => DateTime.UtcNow.ToString("ddd MMM d HH:mm:ss \"UTC\" yyyy", CultureInfo.InvariantCulture);
 
         /// <summary>
         /// Creates a byte array which combines all of the byte[] in values in the order of the array

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoConstants.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoConstants.cs
@@ -35,6 +35,7 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
         public static readonly string ChlgParamDeliveryMed = "CODE_DELIVERY_DELIVERY_MEDIUM";
 
         public static readonly string ChlgParamSmsMfaCode = "SMS_MFA_CODE";
+        public static readonly string ChlgParamSoftwareMfaCode = "SOFTWARE_TOKEN_MFA_CODE";
         public static readonly string ChlgParamDeviceKey = "DEVICE_KEY";
 
         public static readonly string ChlgParamUserAttrs = "userAttributes";

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoDeviceHelper.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoDeviceHelper.cs
@@ -66,6 +66,12 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
 
             Salt = new byte[16];
             random.NextBytes(Salt);
+            //fix negative salt
+            var preBigSalt = new BigInteger(Salt);
+            if (preBigSalt.Sign < 0) {
+                Salt = (-1 * preBigSalt).ToByteArray();
+            }
+
 
             Verifier = CalculateVerifier(Salt, deviceKeyHash);
         }

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.17.4" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.4.3" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.10" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.104.24" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.105.4" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.110.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
1. Up versions for CognitoIdentity and CognitoIdentityProvider(required for mfa auth)
2. Add devece remeber logic and negative salt fix(thar error return from cognito, not always).
3. Add required constants for mfa auth.
4. ForgotPasswordAsync now return CodeDeliveryDetails, may be used for display info to user.
5. Software mfa support for user - Associate(enable mfa), ConfirmCode and update mfa settings.
6. Request send email confirmation code for user
7. Update attributes for user (name or email)
8. Update Readme.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
